### PR TITLE
fix file path error

### DIFF
--- a/InputFile.py
+++ b/InputFile.py
@@ -31,12 +31,12 @@ class InputFile:
 
         if  not self.__is_wave_file( self.wav_file ):   
             self.wav_file.close()
-            canonical_form = self.workingdir + str( time.time() )
+            canonical_form = os.path.join(self.workingdir, str( time.time() ))
             
             #make sure the filename has a ".mp3" extension before sending to lame
             if filename[-4:] != ".mp3" :
                 # create a copy of the file in                 
-                temp_file_name =  self.workingdir + str(time.time()) + ".mp3" 
+                temp_file_name =  os.path.join(self.workingdir, str(time.time()) + ".mp3" )
                 shutil.copyfile( filename, temp_file_name )
                 filename = temp_file_name
             # Use lame to make a wav representation of the mp3 file to be analyzed


### PR DESCRIPTION
Thanks for the useful project!
`canonical_form` and `temp_file_name` generate with `self.workingdir + str(time.time())`, the result likes `/tmp/tmpxxx16xxxxx` rather than `/tmp/tmpxxx/16xxxxx`, It will result in `shutil.rmtree(self.workingdir)` cannot remove them in function `close` and leave many temp files.